### PR TITLE
タスク関連APIのテストを追加

### DIFF
--- a/backend/pkg/authenticator.go
+++ b/backend/pkg/authenticator.go
@@ -50,9 +50,3 @@ func (a firebaseAuth) VerifyIDToken(ctx context.Context, idToken string) (uid st
 
 	return token.UID, nil
 }
-
-//type authenticatorMock struct{}
-//
-//func (a *authenticatorMock) VerifyIDToken(_ context.Context, _ string) (uid string, err error) {
-//	return "someUID", nil
-//}

--- a/backend/pkg/db_operator.go
+++ b/backend/pkg/db_operator.go
@@ -59,86 +59,86 @@ func NewMySQL(ctx context.Context, dsn string) (*mysql, error) {
 	return nil, fmt.Errorf("failed to connect mysql. %w", err)
 }
 
-//type dbOperatorMock struct{}
-//
-//func (o *dbOperatorMock) CreateUser(_ context.Context, _ string) (*user, error) {
-//	return &user{
-//		ID:        1,
-//		DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
-//		RestCount: 0,
-//		CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//		UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//	}, nil
-//}
-//
-//func (o *dbOperatorMock) GetUser(_ context.Context, _ string) (*user, error) {
-//	return &user{
-//		ID:        1,
-//		DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
-//		RestCount: 0,
-//		CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//		UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//	}, nil
-//}
-//
-//func (o *dbOperatorMock) CreateTask(_ context.Context, _ int, _ string, _ int, _ *time.Time) (*task, error) {
-//	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
-//	return &task{
-//		ID:               1,
-//		UserID:           1,
-//		Title:            "タスク1",
-//		EstimatedPomoNum: 4,
-//		DueOn:            &dueOn,
-//		CompletedOn:      nil,
-//		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//	}, nil
-//}
-//
-//func (o *dbOperatorMock) GetTask(_ context.Context, _ int) (*task, error) {
-//	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
-//	return &task{
-//		ID:               1,
-//		UserID:           1,
-//		Title:            "タスク1",
-//		EstimatedPomoNum: 4,
-//		DueOn:            &dueOn,
-//		CompletedOn:      nil,
-//		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//	}, nil
-//}
-//
-//func (o *dbOperatorMock) GetTasks(_ context.Context, _ int, _ *getTasksRequest) ([]*task, error) {
-//	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
-//	return []*task{
-//		{
-//			ID:               1,
-//			UserID:           1,
-//			Title:            "タスク1",
-//			EstimatedPomoNum: 4,
-//			DueOn:            &dueOn,
-//			CompletedOn:      nil,
-//			CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//			UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-//		},
-//		{
-//			ID:               2,
-//			UserID:           1,
-//			Title:            "タスク2",
-//			EstimatedPomoNum: 0,
-//			DueOn:            nil,
-//			CompletedOn:      nil,
-//			CreatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
-//			UpdatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
-//		},
-//	}, nil
-//}
-//
-//func (o *dbOperatorMock) UpdateTask(_ context.Context, _ *task) error {
-//	return nil
-//}
-//
-//func (o *dbOperatorMock) DeleteTask(_ context.Context, _ int) error {
-//	return nil
-//}
+type dbOperatorMock struct{}
+
+func (o *dbOperatorMock) CreateUser(_ context.Context, _ string) (*user, error) {
+	return &user{
+		ID:        1,
+		DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
+		RestCount: 0,
+		CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (o *dbOperatorMock) GetUser(_ context.Context, _ string) (*user, error) {
+	return &user{
+		ID:        1,
+		DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
+		RestCount: 0,
+		CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (o *dbOperatorMock) CreateTask(_ context.Context, _ int, _ string, _ int, _ *time.Time) (*task, error) {
+	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
+	return &task{
+		ID:               1,
+		UserID:           1,
+		Title:            "タスク1",
+		EstimatedPomoNum: 4,
+		DueOn:            &dueOn,
+		CompletedOn:      nil,
+		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (o *dbOperatorMock) GetTask(_ context.Context, _ int) (*task, error) {
+	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
+	return &task{
+		ID:               1,
+		UserID:           1,
+		Title:            "タスク1",
+		EstimatedPomoNum: 4,
+		DueOn:            &dueOn,
+		CompletedOn:      nil,
+		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (o *dbOperatorMock) GetTasks(_ context.Context, _ int, _ *getTasksRequest) ([]*task, error) {
+	dueOn := time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC)
+	return []*task{
+		{
+			ID:               1,
+			UserID:           1,
+			Title:            "タスク1",
+			EstimatedPomoNum: 4,
+			DueOn:            &dueOn,
+			CompletedOn:      nil,
+			CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:               2,
+			UserID:           1,
+			Title:            "タスク2",
+			EstimatedPomoNum: 0,
+			DueOn:            nil,
+			CompletedOn:      nil,
+			CreatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
+		},
+	}, nil
+}
+
+func (o *dbOperatorMock) UpdateTask(_ context.Context, _ *task) error {
+	return nil
+}
+
+func (o *dbOperatorMock) DeleteTask(_ context.Context, _ int) error {
+	return nil
+}

--- a/backend/pkg/db_operator.go
+++ b/backend/pkg/db_operator.go
@@ -86,12 +86,12 @@ func (o *dbOperatorMock) CreateTask(_ context.Context, _ int, _ string, _ int, _
 	return &task{
 		ID:               1,
 		UserID:           1,
-		Title:            "タスク1",
+		Title:            "数学の課題を終わらせる",
 		EstimatedPomoNum: 4,
 		DueOn:            &dueOn,
 		CompletedOn:      nil,
-		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		CreatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+		UpdatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
 	}, nil
 }
 
@@ -100,12 +100,12 @@ func (o *dbOperatorMock) GetTask(_ context.Context, _ int) (*task, error) {
 	return &task{
 		ID:               1,
 		UserID:           1,
-		Title:            "タスク1",
+		Title:            "数学の課題を終わらせる",
 		EstimatedPomoNum: 4,
 		DueOn:            &dueOn,
 		CompletedOn:      nil,
-		CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-		UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+		CreatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+		UpdatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
 	}, nil
 }
 
@@ -115,22 +115,22 @@ func (o *dbOperatorMock) GetTasks(_ context.Context, _ int, _ *getTasksRequest) 
 		{
 			ID:               1,
 			UserID:           1,
-			Title:            "タスク1",
+			Title:            "数学の課題を終わらせる",
 			EstimatedPomoNum: 4,
 			DueOn:            &dueOn,
 			CompletedOn:      nil,
-			CreatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
-			UpdatedAt:        time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+			CreatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+			UpdatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
 		},
 		{
 			ID:               2,
 			UserID:           1,
-			Title:            "タスク2",
+			Title:            "録画しておいた映画を観る",
 			EstimatedPomoNum: 0,
 			DueOn:            nil,
 			CompletedOn:      nil,
-			CreatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
-			UpdatedAt:        time.Date(2021, 7, 10, 0, 0, 0, 0, time.UTC),
+			CreatedAt:        time.Date(2021, 7, 10, 21, 0, 49, 0, time.UTC),
+			UpdatedAt:        time.Date(2021, 7, 10, 21, 0, 49, 0, time.UTC),
 		},
 	}, nil
 }

--- a/backend/pkg/task_handler.go
+++ b/backend/pkg/task_handler.go
@@ -132,7 +132,7 @@ func PatchTask(w http.ResponseWriter, r *http.Request) {
 		LogError("failed to get task.", err)
 		return
 	}
-	if user.HasTask(task) {
+	if !user.HasTask(task) {
 		writeErrorResponse(w, newErrNotFound(errors.New("task is not found")))
 		LogInfo("user does not have access to the task")
 		return

--- a/backend/pkg/task_handler.go
+++ b/backend/pkg/task_handler.go
@@ -200,7 +200,7 @@ func DeleteTask(w http.ResponseWriter, r *http.Request) {
 		LogError("failed to get task.", err)
 		return
 	}
-	if user.HasTask(task) {
+	if !user.HasTask(task) {
 		writeErrorResponse(w, newErrNotFound(errors.New("task is not found")))
 		LogInfo("user does not have access to the task")
 		return

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -276,3 +276,45 @@ func TestPatchTask(t *testing.T) {
 		}
 	}
 }
+
+func TestDeleteTask(t *testing.T) {
+	SetDBOperator(&dbOperatorMock{})
+
+	type want struct {
+		statusCode int
+	}
+	testcases := []struct {
+		name string
+		want want
+	}{
+		{
+			name: "タスクを削除する",
+			want: want{statusCode: 204},
+		},
+	}
+
+	for i, tc := range testcases {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("DELETE", "/tasks/1", nil)
+		r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey,
+			&chi.Context{URLParams: chi.RouteParams{
+				Keys:   []string{"taskID"},
+				Values: []string{"1"},
+			}}))
+		r = r.WithContext(context.WithValue(r.Context(), userKey{},
+			&user{
+				ID:        1,
+				DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
+				RestCount: 0,
+				CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+			}))
+
+		DeleteTask(w, r)
+
+		resp := w.Result()
+		if resp.StatusCode != tc.want.statusCode {
+			t.Errorf("#%d: Response status code should be %d, but %d", i+1, tc.want.statusCode, resp.StatusCode)
+		}
+	}
+}

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -121,3 +121,86 @@ func TestPostTasks(t *testing.T) {
 		}
 	}
 }
+
+func TestGetTasks(t *testing.T) {
+	SetDBOperator(&dbOperatorMock{})
+
+	type want struct {
+		statusCode int
+		response   interface{}
+	}
+	testcases := []struct {
+		name   string
+		target string
+		want   want
+	}{
+		{
+			name:   "タスク一覧を取得する",
+			target: "/tasks",
+			want: want{
+				statusCode: 200,
+				response: tasksResponse{Tasks: []*taskResponse{
+					{
+						ID:               1,
+						Title:            "数学の課題を終わらせる",
+						EstimatedPomoNum: 4,
+						CompletedPomoNum: 0,
+						DueOn:            "2021-07-10T00:00:00Z",
+						CompletedOn:      "",
+						CreatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+						UpdatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+					},
+					{
+						ID:               2,
+						Title:            "録画しておいた映画を観る",
+						EstimatedPomoNum: 0,
+						CompletedPomoNum: 0,
+						DueOn:            "",
+						CompletedOn:      "",
+						CreatedAt:        time.Date(2021, 7, 10, 21, 0, 49, 0, time.UTC),
+						UpdatedAt:        time.Date(2021, 7, 10, 21, 0, 49, 0, time.UTC),
+					},
+				}},
+			},
+		},
+		{
+			name:   "クエリパラメータisCompletedは真偽値である",
+			target: "/tasks?isCompleted=真",
+			want:   want{statusCode: 400},
+		},
+		{
+			name:   "クエリパラメータcompletedOnはRFC 3339 date-time形式である",
+			target: "/tasks?completedOn=2021-07-10",
+			want:   want{statusCode: 400},
+		},
+	}
+
+	for i, tc := range testcases {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", tc.target, nil)
+		r = r.WithContext(context.WithValue(r.Context(), userKey{},
+			&user{
+				ID:        1,
+				DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
+				RestCount: 0,
+				CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+			}))
+
+		GetTasks(w, r)
+
+		resp := w.Result()
+		if resp.StatusCode != tc.want.statusCode {
+			t.Errorf("#%d: Response status code should be %d, but %d", i+1, tc.want.statusCode, resp.StatusCode)
+		}
+		if resp.StatusCode == 200 {
+			var got tasksResponse
+			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+				t.Fatalf("#%d: failed to decode response body. %v", i+1, err)
+			}
+			if diff := cmp.Diff(tc.want.response, got); diff != "" {
+				t.Errorf("#%d: Response body is mismatch (-want +got):\n%s", i+1, diff)
+			}
+		}
+	}
+}

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -1,0 +1,123 @@
+package tomeit
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPostTasks(t *testing.T) {
+	SetDBOperator(&dbOperatorMock{})
+
+	type want struct {
+		statusCode int
+		location   string
+		response   interface{}
+	}
+	testcases := []struct {
+		name    string
+		request postTaskRequest
+		want    want
+	}{
+		{
+			name: "新しいタスクを作成する",
+			request: postTaskRequest{
+				Title:            "数学の課題を終わらせる",
+				EstimatedPomoNum: 4,
+				DueOn:            "2021-07-10T00:00:00Z",
+			},
+			want: want{
+				statusCode: 201,
+				location:   "https://example.com/tasks/1",
+				response: taskResponse{
+					ID:               1,
+					Title:            "数学の課題を終わらせる",
+					EstimatedPomoNum: 4,
+					CompletedPomoNum: 0,
+					DueOn:            "2021-07-10T00:00:00Z",
+					CompletedOn:      "",
+					CreatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+					UpdatedAt:        time.Date(2021, 7, 9, 16, 30, 9, 0, time.UTC),
+				},
+			},
+		},
+		{
+			name: "Titleフィールドは必須である",
+			request: postTaskRequest{
+				Title:            "",
+				EstimatedPomoNum: 4,
+				DueOn:            "2021-07-10T00:00:00Z",
+			},
+			want: want{statusCode: 400},
+		},
+		{
+			name: "EstimatedPomoNumフィールドは0以上4以下の数値である",
+			request: postTaskRequest{
+				Title:            "数学の課題を終わらせる",
+				EstimatedPomoNum: -1,
+				DueOn:            "2021-07-10T00:00:00Z",
+			},
+			want: want{statusCode: 400},
+		},
+		{
+			name: "EstimatedPomoNumフィールドは0以上4以下の数値である",
+			request: postTaskRequest{
+				Title:            "数学の課題を終わらせる",
+				EstimatedPomoNum: 5,
+				DueOn:            "2021-07-10T00:00:00Z",
+			},
+			want: want{statusCode: 400},
+		},
+		{
+			name: "DueOnフィールドの形式はRFC 3339のDate-Timesである",
+			request: postTaskRequest{
+				Title:            "数学の課題を終わらせる",
+				EstimatedPomoNum: 4,
+				DueOn:            "2021-07-10",
+			},
+			want: want{statusCode: 400},
+		},
+	}
+
+	for i, tc := range testcases {
+		data, err := json.Marshal(tc.request)
+		if err != nil {
+			t.Fatalf("#%d: failed to encode request. %v", i+1, err)
+		}
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/tasks", bytes.NewReader(data))
+		r = r.WithContext(context.WithValue(r.Context(), userKey{},
+			&user{
+				ID:        1,
+				DigestUID: "a2c4ba85c41f186283948b1a54efacea04cb2d3f54a88d5826a7e6a917b28c5a",
+				RestCount: 0,
+				CreatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
+			}))
+
+		PostTasks(w, r)
+
+		resp := w.Result()
+		if resp.StatusCode != tc.want.statusCode {
+			t.Errorf("#%d: Response status code should be %d, but %d", i+1, tc.want.statusCode, resp.StatusCode)
+		}
+		if resp.StatusCode == 201 {
+			if location := w.Header().Get("Location"); location != tc.want.location {
+				t.Errorf("#%d: Response header 'Location' should be %v, but %v", i+1, tc.want.location, location)
+			}
+
+			var got taskResponse
+			if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+				t.Fatalf("#%d: failed to decode response body. %v", i+1, err)
+			}
+			if diff := cmp.Diff(tc.want.response, got); diff != "" {
+				t.Errorf("#%d: Response body is mismatch (-want +got):\n%s", i+1, diff)
+			}
+		}
+	}
+}

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -74,7 +74,7 @@ func TestPostTasks(t *testing.T) {
 			want: want{statusCode: 400},
 		},
 		{
-			name: "DueOnフィールドの形式はRFC 3339のDate-Timesである",
+			name: "DueOnフィールドはRFC 3339 date-time形式である",
 			request: postTaskRequest{
 				Title:            "数学の課題を終わらせる",
 				EstimatedPomoNum: 4,


### PR DESCRIPTION
## 追加・変更点

- `PostTasks`関数の単体テストを追加
- `GetTasks`関数の単体テストを追加
- `PatchTask`関数の単体テストを追加
- `DeleteTask`関数の単体テストを追加