### PR TITLE
ハンドラ関数の命名を変更

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -83,7 +83,7 @@ func _main() error {
 		r.Patch("/{taskID}", tomeit.UpdateTask)
 		r.Delete("/{taskID}", tomeit.DeleteTask)
 	})
-	r.Get("/healthz", tomeit.GetHealthz)
+	r.Get("/healthz", tomeit.HealthCheck)
 
 	if err := http.ListenAndServe(":8080", r); err != nil {
 		return fmt.Errorf("failed to run server: %w", err)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -80,7 +80,7 @@ func _main() error {
 	r.Route("/tasks", func(r chi.Router) {
 		r.Post("/", tomeit.CreateTask)
 		r.Get("/", tomeit.GetTasks)
-		r.Patch("/{taskID}", tomeit.PatchTask)
+		r.Patch("/{taskID}", tomeit.UpdateTask)
 		r.Delete("/{taskID}", tomeit.DeleteTask)
 	})
 	r.Get("/healthz", tomeit.GetHealthz)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -78,7 +78,7 @@ func _main() error {
 	r.Use(middleware.Recoverer)
 
 	r.Route("/tasks", func(r chi.Router) {
-		r.Post("/", tomeit.PostTasks)
+		r.Post("/", tomeit.CreateTask)
 		r.Get("/", tomeit.GetTasks)
 		r.Patch("/{taskID}", tomeit.PatchTask)
 		r.Delete("/{taskID}", tomeit.DeleteTask)

--- a/backend/pkg/healthz_handler.go
+++ b/backend/pkg/healthz_handler.go
@@ -2,9 +2,9 @@ package tomeit
 
 import "net/http"
 
-// GetHealthz は"GET /healthz"に対応するハンドラ
-func GetHealthz(w http.ResponseWriter, _ *http.Request) {
-	if err := writeResponse(w, 200, &healthzResponse{Status: "OK"}); err != nil {
+// HealthCheck は"GET /healthz"に対応するハンドラ
+func HealthCheck(w http.ResponseWriter, _ *http.Request) {
+	if err := writeResponse(w, 200, &healthCheckResponse{Status: "OK"}); err != nil {
 		writeErrorResponse(w, newErrInternalServerError(err))
 		LogError("failed to write response.", err)
 	}

--- a/backend/pkg/healthz_handler_test.go
+++ b/backend/pkg/healthz_handler_test.go
@@ -12,15 +12,15 @@ func TestGetHealthz(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/healthz", nil)
 
-	GetHealthz(w, r)
+	HealthCheck(w, r)
 
 	resp := w.Result()
 	if resp.StatusCode != 200 {
 		t.Errorf("got = %d, but want = %d", resp.StatusCode, 200)
 	}
 
-	want := healthzResponse{Status: "OK"}
-	var got healthzResponse
+	want := healthCheckResponse{Status: "OK"}
+	var got healthCheckResponse
 	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
 		t.Fatalf("failed to decode response body. %v", err)
 	}

--- a/backend/pkg/healthz_model.go
+++ b/backend/pkg/healthz_model.go
@@ -1,5 +1,5 @@
 package tomeit
 
-type healthzResponse struct {
+type healthCheckResponse struct {
 	Status string `json:"status"`
 }

--- a/backend/pkg/task_handler.go
+++ b/backend/pkg/task_handler.go
@@ -11,9 +11,9 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// PostTasks は'POST /tasks'エンドポイントに対応するハンドラ
-func PostTasks(w http.ResponseWriter, r *http.Request) {
-	var req postTaskRequest
+// CreateTask は'POST /tasks'エンドポイントに対応するハンドラ
+func CreateTask(w http.ResponseWriter, r *http.Request) {
+	var req createTaskRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeErrorResponse(w, newErrBadRequest(err))
 		LogInfo("failed to decode request.", err)

--- a/backend/pkg/task_handler.go
+++ b/backend/pkg/task_handler.go
@@ -102,9 +102,9 @@ func GetTasks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// PatchTask は'PATCH /tasks/{taskID}'エンドポイントに対応するハンドラ
-func PatchTask(w http.ResponseWriter, r *http.Request) {
-	var req patchTaskRequest
+// UpdateTask は'PATCH /tasks/{taskID}'エンドポイントに対応するハンドラ
+func UpdateTask(w http.ResponseWriter, r *http.Request) {
+	var req updateTaskRequest
 	taskID, err := strconv.Atoi(chi.URLParam(r, "taskID"))
 	if err != nil {
 		writeErrorResponse(w, newErrBadRequest(err))

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -222,12 +222,12 @@ func TestPatchTask(t *testing.T) {
 	)
 	testcases := []struct {
 		name    string
-		request patchTaskRequest
+		request updateTaskRequest
 		want    want
 	}{
 		{
 			name: "タスクを更新する",
-			request: patchTaskRequest{
+			request: updateTaskRequest{
 				Title:            "",
 				EstimatedPomoNum: &estimatedPomoNum,
 				DueOn:            &dueOn,
@@ -237,12 +237,12 @@ func TestPatchTask(t *testing.T) {
 		},
 		{
 			name:    "DueOnフィールドはRFC 3339 date-time形式である",
-			request: patchTaskRequest{DueOn: &badDueOn},
+			request: updateTaskRequest{DueOn: &badDueOn},
 			want:    want{statusCode: 400},
 		},
 		{
 			name:    "CompletedOnフィールドはRFC 3339 date-time形式である",
-			request: patchTaskRequest{CompletedOn: &badCompletedOn},
+			request: updateTaskRequest{CompletedOn: &badCompletedOn},
 			want:    want{statusCode: 400},
 		},
 	}
@@ -268,7 +268,7 @@ func TestPatchTask(t *testing.T) {
 				UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
 			}))
 
-		PatchTask(w, r)
+		UpdateTask(w, r)
 
 		resp := w.Result()
 		if resp.StatusCode != tc.want.statusCode {

--- a/backend/pkg/task_handler_test.go
+++ b/backend/pkg/task_handler_test.go
@@ -23,12 +23,12 @@ func TestPostTasks(t *testing.T) {
 	}
 	testcases := []struct {
 		name    string
-		request postTaskRequest
+		request createTaskRequest
 		want    want
 	}{
 		{
 			name: "新しいタスクを作成する",
-			request: postTaskRequest{
+			request: createTaskRequest{
 				Title:            "数学の課題を終わらせる",
 				EstimatedPomoNum: 4,
 				DueOn:            "2021-07-10T00:00:00Z",
@@ -50,7 +50,7 @@ func TestPostTasks(t *testing.T) {
 		},
 		{
 			name: "Titleフィールドは必須である",
-			request: postTaskRequest{
+			request: createTaskRequest{
 				Title:            "",
 				EstimatedPomoNum: 4,
 				DueOn:            "2021-07-10T00:00:00Z",
@@ -59,7 +59,7 @@ func TestPostTasks(t *testing.T) {
 		},
 		{
 			name: "EstimatedPomoNumフィールドは0以上4以下の数値である",
-			request: postTaskRequest{
+			request: createTaskRequest{
 				Title:            "数学の課題を終わらせる",
 				EstimatedPomoNum: -1,
 				DueOn:            "2021-07-10T00:00:00Z",
@@ -68,7 +68,7 @@ func TestPostTasks(t *testing.T) {
 		},
 		{
 			name: "EstimatedPomoNumフィールドは0以上4以下の数値である",
-			request: postTaskRequest{
+			request: createTaskRequest{
 				Title:            "数学の課題を終わらせる",
 				EstimatedPomoNum: 5,
 				DueOn:            "2021-07-10T00:00:00Z",
@@ -77,7 +77,7 @@ func TestPostTasks(t *testing.T) {
 		},
 		{
 			name: "DueOnフィールドはRFC 3339 date-time形式である",
-			request: postTaskRequest{
+			request: createTaskRequest{
 				Title:            "数学の課題を終わらせる",
 				EstimatedPomoNum: 4,
 				DueOn:            "2021-07-10",
@@ -102,7 +102,7 @@ func TestPostTasks(t *testing.T) {
 				UpdatedAt: time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC),
 			}))
 
-		PostTasks(w, r)
+		CreateTask(w, r)
 
 		resp := w.Result()
 		if resp.StatusCode != tc.want.statusCode {

--- a/backend/pkg/task_model.go
+++ b/backend/pkg/task_model.go
@@ -14,7 +14,7 @@ type (
 		UpdatedAt        time.Time  `db:"updated_at"   goqu:"skipupdate"`
 	}
 
-	postTaskRequest struct {
+	createTaskRequest struct {
 		Title            string `json:"title"`
 		EstimatedPomoNum int    `json:"estimatedPomoNum"`
 		DueOn            string `json:"dueOn"`

--- a/backend/pkg/task_model.go
+++ b/backend/pkg/task_model.go
@@ -23,7 +23,7 @@ type (
 		IsCompleted *bool      `json:"-"`
 		CompletedOn *time.Time `json:"-"`
 	}
-	patchTaskRequest struct {
+	updateTaskRequest struct {
 		TaskID           int     `json:"-"`
 		Title            string  `json:"title"`
 		EstimatedPomoNum *int    `json:"estimatedPomoNum"`


### PR DESCRIPTION
ハンドラ関数の命名を変更する。
これまでは各基本的なエンドポイントの命名規則は`<HTTPメソッド><URL>`のようになっていた。例: `postTasks`、`getTasks`、`patchTask`、`deleteTask`

しかしこれではエンドポイントを示しているだけで実際にどういう動作をするハンドラかが分からず、名前が適切でないと感じていた。
そのため、エンドポイントの動作を名前に適切に入れることにする。こっちの方が大分わかりやすくなったと思う。例: `createTask`、`getTasks`、`updateTask`、`deleteTask`

- [x] `postTasks`を`createTask`に改名
- [x] `patchTask`を`updateTask`に改名
- [x] `getHealthz`を`healthCheck`に改名
